### PR TITLE
feat: add config for trusting proxy

### DIFF
--- a/src/backend_old/app.ts
+++ b/src/backend_old/app.ts
@@ -70,6 +70,7 @@ import errors from '@/shared/errors';
   }
 
   const app = express();
+  app.set('trust proxy', config().proxyTrust);
 
   app.use(bodyparser.json());
 

--- a/src/backend_old/config.ts
+++ b/src/backend_old/config.ts
@@ -4,6 +4,7 @@ interface VacdmConfig {
   mongoUri: string;
   port: number;
   role: 'API' | 'WORKER';
+  proxyTrust: string;
 
   pluginSettings: PluginSettings;
   frontendSettings: FrontendSettings;
@@ -46,6 +47,7 @@ export default function config(): VacdmConfig {
     mongoUri: process.env.MONGO_URI || '',
     port: Number(process.env.PORT) || 3000,
     role: process.env.ROLE != 'WORKER' ? 'API' : 'WORKER',
+    proxyTrust: process.env.PROXY_TRUST || 'loopback',
 
     pluginSettings: {
       serverName: options.serverName,


### PR DESCRIPTION
Add environment variable `PROXY_TRUST` which contains a comma-separated list of CIDRs for trusting the `X-Forwarded-For` header.

[expressjs document](https://expressjs.com/en/guide/behind-proxies.html)